### PR TITLE
Add admin dashboard and validate adicional form

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,15 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
 		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/demo/controller/AdicionalController.java
+++ b/src/main/java/com/example/demo/controller/AdicionalController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.example.demo.model.Adicional;
 import com.example.demo.repository.AdicionalRepository;
 import com.example.demo.repository.CategoriaRepository;
+import jakarta.validation.Valid;
 
 @Controller
 @RequestMapping("/adicionales")
@@ -41,7 +43,13 @@ public class AdicionalController {
 
     // Guardar adicional
     @PostMapping("/guardar")
-    public String guardarAdicional(@ModelAttribute Adicional adicional) {
+    public String guardarAdicional(@Valid @ModelAttribute("adicional") Adicional adicional,
+                                   BindingResult result,
+                                   Model model) {
+        if (result.hasErrors()) {
+            model.addAttribute("categorias", categoriaRepo.findAll());
+            return "form-adicional";
+        }
         adicionalRepo.save(adicional);
         return "redirect:/adicionales";
     }

--- a/src/main/java/com/example/demo/controller/AdminController.java
+++ b/src/main/java/com/example/demo/controller/AdminController.java
@@ -1,0 +1,19 @@
+package com.example.demo.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import jakarta.servlet.http.HttpSession;
+
+@Controller
+public class AdminController {
+
+    @GetMapping("/admin")
+    public String adminDashboard(HttpSession session) {
+        if (session.getAttribute("username") == null) {
+            return "redirect:/la_gruta/login";
+        }
+        return "admin-dashboard"; // templates/admin-dashboard.html
+    }
+}
+

--- a/src/main/java/com/example/demo/model/Adicional.java
+++ b/src/main/java/com/example/demo/model/Adicional.java
@@ -10,6 +10,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -25,12 +29,16 @@ public class Adicional {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotBlank(message = "El nombre es obligatorio")
     @Column(nullable = false)
     private String nombre;
 
+    @Size(max = 500, message = "La descripción no puede exceder 500 caracteres")
     @Column(length = 500)
     private String descripcion;
 
+    @NotNull(message = "El precio es obligatorio")
+    @Positive(message = "El precio debe ser mayor a 0")
     @Column(nullable = false)
     private Double precio;
 
@@ -39,6 +47,7 @@ public class Adicional {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "categoria_id")
+    @NotNull(message = "Seleccione una categoría")
     private Categoria categoria;
 
     /*@OneToMany(fetch = FetchType.LAZY)

--- a/src/main/resources/templates/admin-dashboard.html
+++ b/src/main/resources/templates/admin-dashboard.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;500;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/header-footer.css" />
+</head>
+<body>
+  <header>
+    <div th:replace="fragments :: solid-header"></div>
+  </header>
+
+  <main class="container my-5">
+    <h1 class="mb-4 text-center">Panel de Administración</h1>
+    <div class="row g-4">
+      <div class="col-md-4">
+        <a th:href="@{/comidas}" class="btn btn-primary w-100">Comidas</a>
+      </div>
+      <div class="col-md-4">
+        <a th:href="@{/adicionales}" class="btn btn-primary w-100">Adicionales</a>
+      </div>
+      <div class="col-md-4">
+        <a th:href="@{/users}" class="btn btn-primary w-100">Usuarios</a>
+      </div>
+    </div>
+  </main>
+
+  <footer id="contacto">
+    <div th:replace="fragments :: footer"></div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/form-adicional.html
+++ b/src/main/resources/templates/form-adicional.html
@@ -23,29 +23,8 @@
   </head>
   <body>
     <!-- Header -->
-<header th:fragment="solid-header" class="header-solid">
-        <nav class="container-fluid d-flex justify-content-between align-items-center position-relative">
-
-            <!-- Menú izquierdo -->
-            <ul class="navbar-nav flex-row gap-4 left-menu">
-                <li class="nav-item"><a class="nav-link" href="menu">Menú</a></li>
-                <li class="nav-item"><a class="nav-link" href="restaurantes">Restaurantes</a></li>
-                <li class="nav-item"><a class="nav-link" href="index#sobre-nosotros">Nosotros</a></li>
-            </ul>
-
-            <!-- Logo centrado -->
-            <a class="navbar-brand logo-central position-absolute top-50 start-50 translate-middle" href="index">
-                <img src="../static/images/logoGruta.png" alt="Logo La Gruta Nera">
-            </a>
-
-            <!-- Menú derecho -->
-            <ul class="navbar-nav flex-row gap-4 right-menu align-items-center">
-                <li class="nav-item"><a class="nav-link" href="#contacto">Contacto</a></li>
-                <li class="nav-item"><a class="nav-link btn btn-reserva-header" href="login">Login</a></li>
-                <li class="nav-item"><a class="nav-link btn btn-reserva-header" href="#reservas">Reserva Aquí</a></li>
-            </ul>
-
-        </nav>
+    <header>
+      <div th:replace="fragments :: solid-header"></div>
     </header>
 
     <!-- Contenido principal -->
@@ -73,6 +52,7 @@
                 th:field="*{nombre}"
                 required
               />
+              <div class="text-danger" th:if="${#fields.hasErrors('nombre')}" th:errors="*{nombre}"></div>
             </div>
 
             <div class="mb-3">
@@ -93,6 +73,7 @@
                 th:field="*{precio}"
                 required
               />
+              <div class="text-danger" th:if="${#fields.hasErrors('precio')}" th:errors="*{precio}"></div>
             </div>
 
             <div class="mb-3">
@@ -112,6 +93,7 @@
                   th:selected="${adicional.categoria != null and adicional.categoria.id == cat.id}"
                 ></option>
               </select>
+              <div class="text-danger" th:if="${#fields.hasErrors('categoria')}" th:errors="*{categoria}"></div>
             </div>
 
             <div class="mb-3 form-check">


### PR DESCRIPTION
## Summary
- add admin dashboard with links to manage comidas, adicionales, and users
- introduce validation for adicional creation with error messages
- include Bean Validation dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf91ee5aec83299bc943d879012d64